### PR TITLE
Fix hard-coded status bar height

### DIFF
--- a/SF iOS/SF iOS/Helpers/StatusBarBackgroung/UIViewController+StatusBarBackground.m
+++ b/SF iOS/SF iOS/Helpers/StatusBarBackgroung/UIViewController+StatusBarBackground.m
@@ -18,7 +18,7 @@
     [statusBarBackground.topAnchor constraintEqualToAnchor:self.view.topAnchor].active = true;
     [statusBarBackground.leftAnchor constraintEqualToAnchor:self.view.leftAnchor].active = true;
     [statusBarBackground.rightAnchor constraintEqualToAnchor:self.view.rightAnchor].active = true;
-    [statusBarBackground.heightAnchor constraintEqualToConstant:20].active = true;
+    [statusBarBackground.heightAnchor constraintEqualToConstant:[self statusBarHeight]].active = true;
 }
 
 


### PR DESCRIPTION
Fixes hard-coded 20pt status bar height, which was incorrect for iPhone X/XS/XR models

Before:
<img width="491" alt="Screen Shot 2019-03-29 at 3 52 55 PM" src="https://user-images.githubusercontent.com/1132493/55266599-0d3a8d80-523b-11e9-97ed-e87d1d64410f.png">

After:
<img width="491" alt="Screen Shot 2019-03-29 at 3 53 13 PM" src="https://user-images.githubusercontent.com/1132493/55266605-1cb9d680-523b-11e9-87a3-e6f0c31be483.png">
