### PR TITLE
Only update realm objects if they are different

### DIFF
--- a/SF iOS/SF iOS/Models/Event.m
+++ b/SF iOS/SF iOS/Models/Event.m
@@ -82,4 +82,16 @@
     [self isActive] == [object isActive] &&
     [[self imageFileURLString] isEqualToString:[object imageFileURLString]];
 }
+
+-(NSUInteger)hash {
+    return [[self eventID] hash] +
+    [self type] +
+    [[self date] hash] +
+    [self duration] +
+    [[self venue] hash] +
+    [[self name] hash] +
+    [[self endDate] hash] +
+    [self isActive] +
+    [[self imageFileURLString] hash];
+}
 @end

--- a/SF iOS/SF iOS/Models/Event.m
+++ b/SF iOS/SF iOS/Models/Event.m
@@ -70,4 +70,16 @@
     }
     return [[NSURL alloc] initWithString:self.imageFileURLString];
 }
+
+- (BOOL)isEqual:(Event *)object {
+    return [[self eventID] isEqualToString:[object eventID]] &&
+    [self type] == [object type] &&
+    [[self date] isEqualToDate:[object date]] &&
+    [self duration] == [object duration] &&
+    [[self venue] isEqual:[object venue]] &&
+    [[self name] isEqualToString:[object name]] &&
+    [[self endDate] isEqualToDate:[object endDate]] &&
+    [self isActive] == [object isActive] &&
+    [[self imageFileURLString] isEqualToString:[object imageFileURLString]];
+}
 @end

--- a/SF iOS/SF iOS/Models/Location.m
+++ b/SF iOS/SF iOS/Models/Location.m
@@ -30,4 +30,11 @@
                                       longitude:self.longitude];
 }
 
+- (BOOL)isEqual:(Location *)object {
+    return [[self streetAddress] isEqualToString:[object streetAddress]];
+//    return [[self streetAddress] isEqualToString:[object streetAddress]] &&
+//    [self latitude] == [object latitude] &&
+//    [self longitude] == [object longitude];
+}
+
 @end

--- a/SF iOS/SF iOS/Models/Location.m
+++ b/SF iOS/SF iOS/Models/Location.m
@@ -37,4 +37,7 @@
 //    [self longitude] == [object longitude];
 }
 
+-(NSUInteger)hash {
+    return [[self streetAddress] hash];
+}
 @end

--- a/SF iOS/SF iOS/Models/Venue.m
+++ b/SF iOS/SF iOS/Models/Venue.m
@@ -30,4 +30,9 @@
     return [[NSURL alloc] initWithString:self.venueURLString];
 }
 
+- (BOOL)isEqual:(Venue *)object {
+    return [[self venueURLString] isEqualToString:[object venueURLString]] &&
+    [[self name] isEqualToString:[object name]] &&
+    [[self location] isEqual:[object location]];
+}
 @end

--- a/SF iOS/SF iOS/Models/Venue.m
+++ b/SF iOS/SF iOS/Models/Venue.m
@@ -35,4 +35,8 @@
     [[self name] isEqualToString:[object name]] &&
     [[self location] isEqual:[object location]];
 }
+
+-(NSUInteger)hash {
+    return [[self venueURLString] hash] + [[self name] hash] + [[self location] hash];
+}
 @end

--- a/SF iOS/SF iOSTests/EventTests.m
+++ b/SF iOS/SF iOSTests/EventTests.m
@@ -8,16 +8,20 @@
 
 #import <XCTest/XCTest.h>
 #import "Event.h"
+#import "Venue.h"
 @interface EventTests : XCTestCase
 
 @property (nonatomic) Event *event;
+@property (nonatomic) Event *secondEvent;
 
 @end
 
 @implementation EventTests
 - (void)setUp {
     [super setUp];
-    NSDictionary *location = @{};
+    NSDictionary *location = @{@"formatted_address": @"736 Divisadero St (btwn Grove St Fulton St), San Francisco, CA 94117, United States",
+                               @"latitude": @(37.77632881728594),
+                               @"longitude": @(-122.43802428245543)};
     NSDictionary *venue = @{
                             @"name": @"The Venue Name",
                             @"location": location,
@@ -34,6 +38,9 @@
     self.event = [[Event alloc] initWithDictionary:dict];
     self.event.type = EventTypeSFCoffee;
     self.event.date = [NSDate new];
+    self.secondEvent = [[Event alloc] initWithDictionary:dict];
+    self.secondEvent.type = EventTypeSFCoffee;
+    self.secondEvent.date = self.event.date;
 }
 
 - (void)testName {
@@ -55,5 +62,43 @@
 }
 
 
+- (void)testEqual {
+    XCTAssert([self.event isEqual:self.secondEvent]);
+}
+
+- (void)testEqualNames {
+    self.secondEvent.name = @"something else";
+    XCTAssertFalse([self.event isEqual:self.secondEvent]);
+}
+
+- (void)testEqualDate {
+    self.secondEvent.date = [self.secondEvent.date dateByAddingTimeInterval:1];
+    XCTAssertFalse([self.event isEqual:self.secondEvent]);
+}
+
+- (void)testEqualDuration {
+    self.secondEvent.duration = 123;
+    XCTAssertFalse([self.event isEqual:self.secondEvent]);
+}
+
+- (void)testEqualVenue {
+    self.secondEvent.venue = [[Venue alloc] init];
+    XCTAssertFalse([self.event isEqual:self.secondEvent]);
+}
+
+- (void)testEqualEventID {
+    self.secondEvent.eventID = @"";
+    XCTAssertFalse([self.event isEqual:self.secondEvent]);
+}
+
+- (void)testEqualEndDate {
+    self.secondEvent.endDate = [self.event.endDate dateByAddingTimeInterval:1];
+    XCTAssertFalse([self.event isEqual:self.secondEvent]);
+}
+
+- (void)testEqualImageFileURLString {
+    self.secondEvent.imageFileURLString = @"some url string";
+    XCTAssertFalse([self.event isEqual:self.secondEvent]);
+}
 
 @end

--- a/SF iOS/SF iOSTests/LocationTests.m
+++ b/SF iOS/SF iOSTests/LocationTests.m
@@ -10,6 +10,7 @@
 #import "Location.h"
 @interface LocationTests : XCTestCase
 @property (nonatomic) Location *location;
+@property (nonatomic) Location *secondLocation;
 @end
 
 @implementation LocationTests
@@ -20,6 +21,7 @@
                                    @"longitude" : @35
                                    };
     self.location = [[Location alloc] initWithDictionary:locationDict];
+    self.secondLocation = [[Location alloc] initWithDictionary:locationDict];
 }
 
 - (void)testLatitude {
@@ -32,4 +34,22 @@
 - (void)testTitle {
     XCTAssertEqual(self.location.streetAddress, @"This is the address");
 }
+
+- (void)testEqualStreetAddress {
+    self.secondLocation.streetAddress = @"something different";
+    XCTAssertFalse([self.location isEqual:self.secondLocation]);
+}
+
+// Currently the backend doesn't cache the location as it's own object. As the location given by foursquare changes somewhat frequently we don't use that in our diff calculation.
+
+//- (void)testEqualLatitude {
+//    self.secondLocation.latitude = 123;
+//    XCTAssertFalse([self.location isEqual:self.secondLocation]);
+//}
+//
+//- (void)testEqualLongitude {
+//    self.secondLocation.longitude = 123;
+//    XCTAssertFalse([self.location isEqual:self.secondLocation]);
+//}
+
 @end

--- a/SF iOS/SF iOSTests/VenueTests.m
+++ b/SF iOS/SF iOSTests/VenueTests.m
@@ -8,9 +8,11 @@
 
 #import <XCTest/XCTest.h>
 #import "Venue.h"
+#import "Location.h"
+
 @interface VenueTests : XCTestCase
 @property (nonatomic) Venue *venue;
-
+@property (nonatomic) Venue *secondVenue;
 @end
 
 @implementation VenueTests
@@ -23,6 +25,7 @@
                                       @"url": @"https://foursquare.com/v/four-barrel-coffee/480d1a5ef964a520284f1fe3"
                                       };
     self.venue = [[Venue alloc] initWithDictionary:venueDictionary];
+    self.secondVenue = [[Venue alloc] initWithDictionary:venueDictionary];
 }
 
 - (void)testName {
@@ -33,4 +36,21 @@
     NSURL *URL = [[NSURL alloc] initWithString:@"https://foursquare.com/v/four-barrel-coffee/480d1a5ef964a520284f1fe3"];
     XCTAssertTrue([self.venue.venueURL isEqual:URL]);
 }
+
+-(void)testEqualURL {
+    self.secondVenue.venueURLString = @"something else";
+    XCTAssertFalse([self.venue isEqual:self.secondVenue]);
+}
+
+-(void)testEqualLocation {
+    self.secondVenue.location = [[Location alloc] init];
+    XCTAssertFalse([self.venue isEqual:self.secondVenue]);
+}
+
+-(void)testEqualName {
+    self.secondVenue.name = @"something else";
+    XCTAssertFalse([self.venue isEqual:self.secondVenue]);
+}
+
+
 @end


### PR DESCRIPTION
- Update model to include `isEqual:`
- Add tests to verify each step
- Use the equivalence method to determine if we have an actual update

This minimizes the number of items we are sending to the delegate from the data source when the data service tells us things have change. 