### PR TITLE
Fix clearing the application badge value

### DIFF
--- a/SF iOS/SF iOS/AppDelegate.m
+++ b/SF iOS/SF iOS/AppDelegate.m
@@ -25,8 +25,6 @@
 }
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
-
     UNUserNotificationCenter *notificationCenter = [UNUserNotificationCenter currentNotificationCenter];
     UNAuthorizationOptions options = UNAuthorizationOptionAlert|UNAuthorizationOptionBadge|UNAuthorizationOptionSound;
     [notificationCenter requestAuthorizationWithOptions:options
@@ -40,6 +38,8 @@
 
 - (void)applicationDidBecomeActive:(UIApplication *)application {
     // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+    [[UIApplication sharedApplication] setApplicationIconBadgeNumber:0];
+
     [[NSNotificationCenter defaultCenter] postNotificationName:NSNotification.applicationBecameActiveNotification object:nil];
 }
 


### PR DESCRIPTION
Clear application badge value when applicationDidBecomeActive, instead of didFinishLaunchingWithOptions; otherwise badges won't be cleared if the app was in the background or inactive state.