### PR TITLE
Prevent notifications for past events.

### DIFF
--- a/SF iOS/SF iOS/Helpers/UserNotification/BackgroundFetcher.m
+++ b/SF iOS/SF iOS/Helpers/UserNotification/BackgroundFetcher.m
@@ -48,9 +48,14 @@
     NSInteger currentBadgeCount = [[UIApplication sharedApplication] applicationIconBadgeNumber];
 
     for (NSIndexPath *update in updates) {
-        NSString *contentTitle = NSLocalizedString(@"Coffee Event changed",
-                                                   @"notification title for changed events");
         Event *event = [self.backgroundDataSource eventAtIndex:[update row]];
+        // Prevent notifications if changes, e.g. images and URLs, are made to past events
+        if ([[event endDate] isInFuture] == NO) {
+            continue;
+        }
+        
+        NSString *contentTitle = NSLocalizedString(@"Coffee Event changed",
+                                                   @"notification title for changed events");        
         NSString *bodyTemplate = NSLocalizedString(@"%@'s %@ at %@ has changed. Find the latest info in app.",
                                                    @"notification body: <Date>'s <Event name> at <venue name> has changed");
         NSString *contentBody = [NSString stringWithFormat:bodyTemplate,

--- a/SF iOS/SF iOS/Helpers/UserNotification/BackgroundFetcher.m
+++ b/SF iOS/SF iOS/Helpers/UserNotification/BackgroundFetcher.m
@@ -50,7 +50,7 @@
     for (NSIndexPath *update in updates) {
         Event *event = [self.backgroundDataSource eventAtIndex:[update row]];
         // Prevent notifications if changes, e.g. images and URLs, are made to past events
-        if ([[event endDate] compare:[NSDate date]] == NSOrderedAscending) {
+        if ([[event endDate] isInFuture] == NO) {
             continue;
         }
         

--- a/SF iOS/SF iOS/Helpers/UserNotification/BackgroundFetcher.m
+++ b/SF iOS/SF iOS/Helpers/UserNotification/BackgroundFetcher.m
@@ -48,9 +48,14 @@
     NSInteger currentBadgeCount = [[UIApplication sharedApplication] applicationIconBadgeNumber];
 
     for (NSIndexPath *update in updates) {
-        NSString *contentTitle = NSLocalizedString(@"Coffee Event changed",
-                                                   @"notification title for changed events");
         Event *event = [self.backgroundDataSource eventAtIndex:[update row]];
+        // Prevent notifications if changes, e.g. images and URLs, are made to past events
+        if ([[event endDate] compare:[NSDate date]] == NSOrderedAscending) {
+            continue;
+        }
+        
+        NSString *contentTitle = NSLocalizedString(@"Coffee Event changed",
+                                                   @"notification title for changed events");        
         NSString *bodyTemplate = NSLocalizedString(@"%@'s %@ at %@ has changed. Find the latest info in app.",
                                                    @"notification body: <Date>'s <Event name> at <venue name> has changed");
         NSString *contentBody = [NSString stringWithFormat:bodyTemplate,


### PR DESCRIPTION
Update BackgroundFetcher.m to prevent notifications when events in the past are updated.
https://github.com/ThumbWorks/sf-ios/issues/53