### PR TITLE
Feature/improved image caching

### DIFF
--- a/SF iOS/SF iOS/AppDelegate.m
+++ b/SF iOS/SF iOS/AppDelegate.m
@@ -30,6 +30,8 @@
     [notificationCenter requestAuthorizationWithOptions:options
                                       completionHandler:^(BOOL granted, NSError *error){}];
 
+    [self setSharedNetworkCacheMemoryMegabytes:5
+                                 diskMegabytes:25];
     [application setMinimumBackgroundFetchInterval:UIApplicationBackgroundFetchIntervalMinimum];
 
     [self.navigationContainer.window makeKeyAndVisible];
@@ -54,4 +56,16 @@
         self.bgFetcher = nil;
     }];
 }
+
+//MARK: - Configure cache
+- (void)setSharedNetworkCacheMemoryMegabytes:(NSInteger)memoryMiB diskMegabytes:(NSInteger)diskMiB
+{
+    NSUInteger cashSize = memoryMiB * 1024 * 1024;
+    NSUInteger cashDiskSize = diskMiB * 1024 * 1024;
+    NSURLCache *imageCache = [[NSURLCache alloc] initWithMemoryCapacity:cashSize
+                                                           diskCapacity:cashDiskSize
+                                                               diskPath:@"networking"];
+    [NSURLCache setSharedURLCache:imageCache];
+}
+
 @end

--- a/SF iOS/SF iOS/RemoteUIImage/UIImage+URL.m
+++ b/SF iOS/SF iOS/RemoteUIImage/UIImage+URL.m
@@ -16,13 +16,13 @@
     if (!queue) {
         queue = [NSOperationQueue new];
     }
-    [self setSharedImageCacheMegabytes:25];
 
     [queue addOperationWithBlock:^{
         NSURLSession *sharedSession = [NSURLSession sharedSession];
         NSURLRequest *request = [[NSURLRequest alloc] initWithURL:fileURL
                                                       cachePolicy:NSURLRequestReturnCacheDataElseLoad
                                                   timeoutInterval:30];
+        
         [[sharedSession dataTaskWithRequest:request
                          completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
             UIImage *image = nil;
@@ -34,16 +34,6 @@
             }];
         }] resume];
     }];
-}
-
-+ (void)setSharedImageCacheMegabytes:(NSInteger)megabytes
-{
-    NSUInteger cashSize = megabytes * 1024 * 1024;
-    NSUInteger cashDiskSize = megabytes * 1024 * 1024;
-    NSURLCache *imageCache = [[NSURLCache alloc] initWithMemoryCapacity:cashSize
-                                                           diskCapacity:cashDiskSize
-                                                               diskPath:@"images"];
-    [NSURLCache setSharedURLCache:imageCache];
 }
 
 @end


### PR DESCRIPTION
This branch adds network caching. All network requests should be cached to some degree. Even between launches.

WITH THIS FEATURE
Given a coffee fan
And app
When networking is enabled
Then networked requests are cached
And UI is populated with events
And UI for events has images

When networking is not enabled
Then network requests are fulfilled by the previously cached data
And UI shows “Error fetching events” dialog
And UI is populated with events
And UI for events has images

UNLIKE TODAY
Given a coffee fan
And app
When networking is not enabled
And UI shows “Error fetching events” dialog
Then network requests are not fulfilled (in any circumstance)
And UI is not populated with events
And UI for events do not have images