### PR TITLE
Anchor to the top so events go behind the nav like the group vc

### DIFF
--- a/SF iOS/SF iOS/Feed/EventsFeedViewController.m
+++ b/SF iOS/SF iOS/Feed/EventsFeedViewController.m
@@ -184,7 +184,7 @@ NS_ASSUME_NONNULL_END
 }
 
 - (void)addConstraints {
-    [self.tableView.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor].active = true;
+    [self.tableView.topAnchor constraintEqualToAnchor:self.view.topAnchor].active = true;
     [self.tableView.leftAnchor constraintEqualToAnchor:self.view.leftAnchor].active = true;
     [self.tableView.rightAnchor constraintEqualToAnchor:self.view.rightAnchor].active = true;
     [self.tableView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor].active = true;


### PR DESCRIPTION
Updated the event feed to match the translucency shown when groups go behind group nav http://hi.buffer.com/7812f63958c6