### PR TITLE
Fix issue table view scroll position jumps when navigating back from event details screen

### DIFF
--- a/SF iOS/SF iOS/Feed/EventsFeedViewController.m
+++ b/SF iOS/SF iOS/Feed/EventsFeedViewController.m
@@ -223,7 +223,8 @@ NS_ASSUME_NONNULL_END
     
     // Content Inset was causing some jank when loading SF Coffee, others were fine.
     self.tableView.tableHeaderView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, 16)];
-    
+    self.tableView.estimatedRowHeight = self.cellHeight;
+
     [self configureNoResultsView];
     
     self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAction
@@ -281,7 +282,7 @@ NS_ASSUME_NONNULL_END
 
 - (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
-    [self.tableView reloadData];
+
     self.tableView.refreshControl = [[UIRefreshControl alloc] init];
     [self.tableView.refreshControl addTarget:self.dataSource action:@selector(refresh) forControlEvents:UIControlEventAllEvents];
 }


### PR DESCRIPTION
![detective-pikachu](https://user-images.githubusercontent.com/3249850/58071704-5b408300-7b52-11e9-9a3d-ffef69b3bbb8.gif)

## Fixes 🔨
Apparently, `[tableView reloadData]` call in `viewDidAppear` causes cell height re-calculation. The calculation is expensive due to missing good `estimatedRowHeight`. It causes the delay in rendering table view after `reloadData`. Guess by Detective Pikachu (just kidding, it's my guess).

tl;dr: [reference to a question on Stackoverflow](https://stackoverflow.com/a/34323679/3391537)

## Gifs 📱
| Before | After |
| --- | --- |
| ![before-table-view-scroll-position-jump-issue](https://user-images.githubusercontent.com/3249850/58071451-95f5eb80-7b51-11e9-9a22-c3a10d2f105e.gif) | ![after-table-view-scroll-position-jump-issue](https://user-images.githubusercontent.com/3249850/58071456-9db59000-7b51-11e9-8e40-a65b5005593c.gif) |