### PR TITLE
Use groups in predicates

### DIFF
--- a/SF iOS/SF iOS/Models/EventDataSource.m
+++ b/SF iOS/SF iOS/Models/EventDataSource.m
@@ -153,7 +153,7 @@
 ///     -searchTerm: string to search
 /// - returns: RLMResults<Event *>* array of Events
 - (RLMResults<Event *> *)filterEventsWithSearchTerm:(NSString *)searchTerm {    
-    NSPredicate *coffeeFilter = [NSPredicate predicateWithFormat:@"name CONTAINS[c] %@ OR venue.name CONTAINS[c] %@ && groupID = %@", searchTerm, searchTerm, self.groupID];
+    NSPredicate *coffeeFilter = [NSPredicate predicateWithFormat:@"(name CONTAINS[c] %@ OR venue.name CONTAINS[c] %@) && groupID = %@", searchTerm, searchTerm, self.groupID];
     RLMResults<Event *> *filteredCoffee = [[Event objectsWithPredicate:coffeeFilter]
                                            sortedResultsUsingKeyPath:@"date" ascending:false];
     return filteredCoffee;

--- a/SF iOS/SF iOS/Models/EventDataSource.m
+++ b/SF iOS/SF iOS/Models/EventDataSource.m
@@ -160,7 +160,9 @@
 }
 
 - (NSUInteger)indexOfCurrentEvent {
-    NSPredicate *futureEvents = [NSPredicate predicateWithFormat:@"endDate > %@", [NSDate date]];
+    NSPredicate *futureEvents = [NSPredicate predicateWithFormat:@"endDate > %@ && groupID = %@",
+                                 [NSDate date],
+                                 self.groupID];
     RLMResults<Event *> *filteredCoffee = [[Event objectsWithPredicate:futureEvents]
                                            sortedResultsUsingKeyPath:@"date" ascending:true];
     Event *next = [filteredCoffee firstObject];


### PR DESCRIPTION
2 quick bugs fixed which were overlooked when we moved to the group mechanism. We essentially were using the entire realm to filter and find events when really we should have been filtering with the groupID. 

This occurred in:
1. searching (search for "Blue Bottle" in WWDC should show no results, but it was showing results because "Blue Bottle" was in SF iOS Coffee
2. Finding the index of the next event was not working properly for the same reason. Only 1 group would have proper scroll to next event functionality. Now they all do.