### PR TITLE
Fix locale in Event initialiser

### DIFF
--- a/SF iOS/SF iOS/Models/Event.m
+++ b/SF iOS/SF iOS/Models/Event.m
@@ -19,6 +19,8 @@
         self.type = 0;
         NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
         [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZ"];
+        NSLocale *locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US"];
+        [formatter setLocale:locale];
         NSString *startAt = record[@"start_at"];
         self.date = [formatter dateFromString:startAt];
         self.endDate = [formatter dateFromString:record[@"end_at"]];


### PR DESCRIPTION
Devices with a locale other than en_US were causing the formatter to return nil date when parsing the date string.

Pinning it to en_US should allows for consistency across all devices when parsing the date.

Related to #129, causing Event object with (null) date trying to be loaded.

Would recommend some additional testing, to confirm that this is the correct change!

Thanks