### PR TITLE
Remove two inconsistent date tests

### DIFF
--- a/SF iOS/SF iOSTests/DateTests.m
+++ b/SF iOS/SF iOSTests/DateTests.m
@@ -26,21 +26,5 @@
     XCTAssertTrue([earlier isEarlierThanDate:now]);
 }
 
-- (void)testTimeSlotWhenStartAndEndDatesAreInTheSamePeriod {
-    NSDate *now = [[NSDate alloc] initWithTimeIntervalSince1970:2000];
-    NSDate *start = [[NSCalendar currentCalendar] startOfDayForDate:now];
-    NSString *timesot = [NSDate timeslotStringFromStartDate:start duration:1800];
-    
-    XCTAssertTrue([@"12:00 - 12:30AM" isEqualToString:timesot]);
-}
-
-- (void)testTimeSlotWhenStartAndEndDatesAreInDifferentPeriod {
-    NSDate *now = [[NSDate alloc] initWithTimeIntervalSince1970:2000];
-    NSDate *start = [[NSCalendar currentCalendar] startOfDayForDate:now];
-    NSString *timesot = [NSDate timeslotStringFromStartDate:start duration:13 * 60 * 60]; // 13hrs later
-    
-    XCTAssertTrue([@"12:00AM - 1:00PM" isEqualToString:timesot]);
-}
-
 
 @end


### PR DESCRIPTION
Removed testTimeSlotWhenStartAndEndDatesAreInTheSamePeriod and testTimeSlotWhenStartAndEndDatesAreInDifferentPeriod.

The two tests were inconsistent across different device locale e.g pass on en_US and fail on en_GB (due to producing lower case am/pm).