### PR TITLE
Communicate to user that directions are not available as appropriate.

### DIFF
--- a/SF iOS/SF iOS/EventDetails/EventDetailsViewController.m
+++ b/SF iOS/SF iOS/EventDetails/EventDetailsViewController.m
@@ -101,6 +101,9 @@ NS_ASSUME_NONNULL_END
                                                                             // show error
                                                                         }
                                                                     }];
+                            }
+                            noDirectionsAvailableHandler:^(TransportType transportType) {
+                                [self presentNoDirectionsAvailableAlertFor:transportType];
                             }];
     self.travelTimesView.layoutMargins = UIEdgeInsetsMake(32, 21, 21, 21);
     self.travelTimesView.translatesAutoresizingMaskIntoConstraints = false;
@@ -174,6 +177,36 @@ NS_ASSUME_NONNULL_END
     } shouldQueueIfLocationIsUnavailable:true];
 }
 
+- (void) presentNoDirectionsAvailableAlertFor:(TransportType )transportType {
+    NSString *transportDirectionsTypeName;
+    switch (transportType) {
+        case TransportTypeTransit:
+            transportDirectionsTypeName = @"Transit directions";
+            break;
+        case TransportTypeWalking:
+            transportDirectionsTypeName = @"Walking directions";
+            break;
+        case TransportTypeAutomobile:
+            transportDirectionsTypeName = @"Driving directions";
+            break;
+        case TransportTypeUber:
+            transportDirectionsTypeName = @"Uber rides";
+            break;
+        case TransportTypeLyft:
+            transportDirectionsTypeName = @"Lyft rides";
+            break;
+    }
+    NSString *transportMessage = [NSString stringWithFormat: @"%@ are not available from this location.", transportDirectionsTypeName];
+    UIAlertController* alert = [UIAlertController alertControllerWithTitle:@"Sorry!"
+                                                                   message:transportMessage
+                                                            preferredStyle:UIAlertControllerStyleAlert];
+
+    UIAlertAction* defaultAction = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault
+                                                          handler:^(UIAlertAction * action) {}];
+
+    [alert addAction:defaultAction];
+    [self presentViewController:alert animated:YES completion:nil];
+}
 // MARK: Share
 
 - (void)share {

--- a/SF iOS/SF iOS/EventDetails/TravelTimeView.h
+++ b/SF iOS/SF iOS/EventDetails/TravelTimeView.h
@@ -15,7 +15,7 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface TravelTimeView : UIControl <Styleable>
 
-- (instancetype)initWithTravelTime:(TravelTime *)travelTime arrival:(Arrival)arrival directionsRequestHandler:(DirectionsRequestHandler)directionsRequestHandler NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithTravelTime:(TravelTime *)travelTime arrival:(Arrival)arrival directionsRequestHandler:(DirectionsRequestHandler)directionsRequestHandler noDirectionsAvailableHandler:(DirectionsRequestHandler)noDirectionsAvailableHandler NS_DESIGNATED_INITIALIZER;
 
 @end
 NS_ASSUME_NONNULL_END

--- a/SF iOS/SF iOS/EventDetails/TravelTimesView.h
+++ b/SF iOS/SF iOS/EventDetails/TravelTimesView.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, assign) BOOL loading;
 
-- (instancetype)initWithDirectionsRequestHandler:(DirectionsRequestHandler)directionsRequestHandler NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithDirectionsRequestHandler:(DirectionsRequestHandler)directionsRequestHandler noDirectionsAvailableHandler:(DirectionsRequestHandler)noDirectionsAvailableHandler NS_DESIGNATED_INITIALIZER;
 
 - (void)configureWithTravelTimes:(NSArray<TravelTime *> *)travelTimes eventStartDate:(NSDate *)startDate endDate:(NSDate *)endDate;
 

--- a/SF iOS/SF iOS/EventDetails/TravelTimesView.m
+++ b/SF iOS/SF iOS/EventDetails/TravelTimesView.m
@@ -22,14 +22,17 @@ typedef NS_ENUM(NSUInteger, TravelTimeType) {
 @property (nonatomic) UIStackView *ridesharingStack;
 @property (nonatomic) UIActivityIndicatorView *loadingIndicator;
 @property (copy, nonatomic) DirectionsRequestHandler directionsRequestHandler;
+@property (copy, nonatomic) DirectionsRequestHandler noDirectionsAvailableHandler;
 
 @end
 
 @implementation TravelTimesView
 
-- (instancetype)initWithDirectionsRequestHandler:(DirectionsRequestHandler)directionsRequestHandler {
+- (instancetype)initWithDirectionsRequestHandler:(DirectionsRequestHandler)directionsRequestHandler
+                    noDirectionsAvailableHandler:(DirectionsRequestHandler)noDirectionsAvailableHandler {
     if (self = [super initWithFrame:CGRectZero]) {
         self.directionsRequestHandler = directionsRequestHandler;
+        self.noDirectionsAvailableHandler = noDirectionsAvailableHandler;
         [self setup];
     }
     return self;
@@ -37,12 +40,14 @@ typedef NS_ENUM(NSUInteger, TravelTimeType) {
 
 - (instancetype)initWithCoder:(NSCoder *)coder {
     NSAssert(false, @"use initWithDirectionsRequestHandler:");
-    return [self initWithDirectionsRequestHandler:^(TransportType transportType) {}];
+    return [self initWithDirectionsRequestHandler:^(TransportType transportType) {}
+                     noDirectionsAvailableHandler:^(TransportType transportType) {}];
 }
 
 - (instancetype)initWithFrame:(CGRect)frame {
     NSAssert(false, @"use initWithDirectionsRequestHandler:");
-    return [self initWithDirectionsRequestHandler:^(TransportType transportType) {}];
+    return [self initWithDirectionsRequestHandler:^(TransportType transportType) {}
+                     noDirectionsAvailableHandler:^(TransportType transportType) {}];
 }
 
 - (void)setLoading:(BOOL)loading {
@@ -101,7 +106,10 @@ typedef NS_ENUM(NSUInteger, TravelTimeType) {
 - (void)populateTravelTimeViewsInStack:(nonnull UIStackView *)stack withTimes:(nonnull NSArray *)travelTimes startDate:(NSDate *)startDate endDate:(NSDate *)endDate {
     for (TravelTime *time in travelTimes) {
         Arrival arrival = [time arrivalToEventWithStartDate:startDate endDate:endDate];
-        TravelTimeView *view = [[TravelTimeView alloc] initWithTravelTime:time arrival:arrival directionsRequestHandler:self.directionsRequestHandler];
+        TravelTimeView *view = [[TravelTimeView alloc] initWithTravelTime:time
+                                                                  arrival:arrival
+                                                 directionsRequestHandler:self.directionsRequestHandler
+                                             noDirectionsAvailableHandler:self.noDirectionsAvailableHandler];
         [stack addArrangedSubview:view];
     }
 }

--- a/SF iOS/SF iOS/Location/TravelTime/TravelTime+Arrival.h
+++ b/SF iOS/SF iOS/Location/TravelTime/TravelTime+Arrival.h
@@ -12,6 +12,7 @@ typedef NS_ENUM(NSUInteger, Arrival) {
     ArrivalOnTime,
     ArrivalDuringEvent,
     ArrivalAfterEvent,
+    ArrivalImpossible,
 };
 
 @interface TravelTime (Arrival)

--- a/SF iOS/SF iOS/Location/TravelTime/TravelTime+Arrival.m
+++ b/SF iOS/SF iOS/Location/TravelTime/TravelTime+Arrival.m
@@ -12,6 +12,10 @@
 @implementation TravelTime (Arrival)
 
 - (Arrival)arrivalToEventWithStartDate:(NSDate *)startDate endDate:(NSDate *)endDate {
+    if (self.travelTime < 0) {
+        return ArrivalImpossible;
+    }
+
     // if the event is in the past, magnitudes do not matter
     if ([endDate isEarlierThanDate:[NSDate new]]) {
         return ArrivalOnTime;

--- a/SF iOS/SF iOS/Location/TravelTime/TravelTime.m
+++ b/SF iOS/SF iOS/Location/TravelTime/TravelTime.m
@@ -70,6 +70,9 @@
 }
 
 - (NSString *)travelTimeEstimateString {
+    if (self.travelTime < 0) {
+        return @"—";
+    }
     return [NSDate abbreviatedTimeIntervalForTimeInterval:self.travelTime];
 }
 

--- a/SF iOS/SF iOS/Location/TravelTime/TravelTimeService.m
+++ b/SF iOS/SF iOS/Location/TravelTime/TravelTimeService.m
@@ -93,12 +93,14 @@
     return [[AsyncBlockOperation alloc] initWithAsyncBlock:^(dispatch_block_t  _Nonnull completionHandler) {
         MKDirections *direction = [[MKDirections alloc] initWithRequest:request];
         [direction calculateETAWithCompletionHandler:^(MKETAResponse * _Nullable response, NSError * _Nullable error) {
+            NSTimeInterval travelTime;
             if (!response) {
                 NSLog(@"Could not get travel time for request:\n%@\n%@", request, error);
-                resultHandler(nil);
-                completionHandler();
+                travelTime = -1;
+            } else {
+                travelTime = response.expectedTravelTime;
             }
-            TravelTime *result = [[TravelTime alloc] initWithMKDirectionsTransportType:request.transportType travelTime:response.expectedTravelTime];
+            TravelTime *result = [[TravelTime alloc] initWithMKDirectionsTransportType:request.transportType travelTime:travelTime];
             resultHandler(result);
             completionHandler();
         }];


### PR DESCRIPTION
Currently when no directions are available, a `TransitTimeView` is still created with an ETA of 0 minutes. This can be simply resolved by inserting a `return` in `travelTimeCalculationWithRequest` at the end of the `if (!response)` block. However, this results in a "missing" directions button. Explicitly adding an alert explaining that directions are not available is friendlier to the enduser.

Resolves #150.
===
Create alert message for when directions are not available.
Properly handle scenario where no valid response is provided.
Pass along no-valid-reponse situation.
Allow for handling of scenario where no directions are available.